### PR TITLE
Build fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - GIT_COMMIT_SHA=${COMMIT_SHA:-unknown}
       - APP_VERSION=${VERSION:-unknown}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
     ports:
       - "8000:8000"
     networks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "Pillow>=9.3.0",
     "tqdm>=4.64.1",
     "langchain>=0.0.321",
+    "langchain-community>=0.0.1",
     "requests>=2.28.1",
     "python-multipart>=0.0.6",
     "tiktoken>=0.4.0",


### PR DESCRIPTION
This adds a missing langchain community dependency and ensures the Open AI API key is passed into the container via `docker compose`